### PR TITLE
Type annotations and pattern matching for better control flow and readability

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -31,17 +31,18 @@ fn main() {
     let mut mount = Mount::new();
     let path = Path::new(&opt.input);
     if !path.exists() {
-            println!("Path \"{}\" does not exist.",&opt.input);
+            println!("Path \"{}\" does not exist.", &opt.input);
             return;
     }
     if !path.is_dir() {
-            println!("Path \"{}\" is not a directory.",&opt.input);
+            println!("Path \"{}\" is not a directory.", &opt.input);
             return;
     }
-    println!("Starting up http-server, serving {}",&opt.input);
-    mount.mount("/", Static::new(path));
+    println!("Starting up http-server, serving {}", &opt.input);
     println!("Available on:");
-    println!("  http://{}:{}",opt.address, opt.port);
+    println!("  http://{}:{}", opt.address, opt.port);
     println!("Hit CTRL-C to stop the server");
+
+    mount.mount("/", Static::new(path));
     Iron::new(mount).http((&*opt.address, opt.port)).unwrap();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,22 +27,30 @@ struct Opt {
 }
 
 fn main() {
-    let opt = Opt::from_args();
-    let mut mount = Mount::new();
-    let path = Path::new(&opt.input);
+    let opt: Opt = Opt::from_args();
+    let port: u16 = opt.port;
+    let address: &str = &*opt.address;
+    let input: String = opt.input;
+    let path: &Path = Path::new(&input);
+
     if !path.exists() {
-            println!("Path \"{}\" does not exist.", &opt.input);
-            return;
+        println!("Path \"{}\" does not exist.", input);
+        return
     }
     if !path.is_dir() {
-            println!("Path \"{}\" is not a directory.", &opt.input);
-            return;
+        println!("Path \"{}\" is not a directory.", input);
+        return
     }
-    println!("Starting up http-server, serving {}", &opt.input);
-    println!("Available on:");
-    println!("  http://{}:{}", opt.address, opt.port);
-    println!("Hit CTRL-C to stop the server");
-
+    let mut mount: Mount = Mount::new();
     mount.mount("/", Static::new(path));
-    Iron::new(mount).http((&*opt.address, opt.port)).unwrap();
+
+    match Iron::new(mount).http((address, port)) {
+        Ok(_f) => {
+            println!("Starting up http-server, serving {}", input);
+            println!("Available on:");
+            println!("  http://{}:{}", address, port);
+            println!("Hit CTRL-C to stop the server")
+        }
+        Err(err) => println!("{}", err)
+    }
 }


### PR DESCRIPTION
This pull request is comprised primarily of two changes:

* **Type annotations** - Even though Rust has type inference, explicitly writing out types can be useful for documentation. This resulted in creating variables for each command line argument, although this arguably increases readability anyway.

* **Pattern matching** - The server in its previous state would panic in certain situations such as attempting to use a low port number (e.g., 80) without permissions or if attempting to use a port that's already in use, and would occur after printing the expected text. By using pattern matching, it'll either print the expected text after successfully starting the server, or print an error message after failing.