### PR TITLE
Exit codes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ fn main() {
     mount.mount("/", Static::new(path));
 
     match Iron::new(mount).http((address, port)) {
-        Ok(_f) => {
+        Ok(_) => {
             println!("Starting up http-server, serving {}", input);
             println!("Available on:");
             println!("  http://{}:{}", address, port);

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ extern crate iron;
 extern crate staticfile;
 extern crate mount;
 use std::path::Path;
+use std::process::exit;
 use iron::Iron;
 use staticfile::Static;
 use mount::Mount;
@@ -35,11 +36,11 @@ fn main() {
 
     if !path.exists() {
         println!("Path \"{}\" does not exist.", input);
-        return
+        exit(1)
     }
     if !path.is_dir() {
         println!("Path \"{}\" is not a directory.", input);
-        return
+        exit(1)
     }
     let mut mount: Mount = Mount::new();
     mount.mount("/", Static::new(path));
@@ -51,6 +52,9 @@ fn main() {
             println!("  http://{}:{}", address, port);
             println!("Hit CTRL-C to stop the server")
         }
-        Err(err) => println!("{}", err)
+        Err(err) => {
+            println!("{}", err);
+            exit(1)
+        }
     }
 }


### PR DESCRIPTION
This is just a small change that uses `exit()` instead of `return`. `exit()` is more explicit about terminating the program, while `return` is typically used for returning a value from a function. There are also exit codes used, which can be useful in situations where you want to test whether a program failed, i.e., `echo $?`.